### PR TITLE
Do not require clean working dir on release-it

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -3,8 +3,9 @@ module.exports = {
     changelog: 'echo "## Changelog\n\n$(npx @uphold/github-changelog-generator -f unreleased | tail -n +4 -f)"',
     commitMessage: 'Release ${version}',
     requireBranch: 'master',
+    requireCleanWorkingDir: false,
     requireCommits: true,
-    tagName: 'v${version}'
+    tagName: 'v${version}',
   },
   github: {
     release: true,


### PR DESCRIPTION
Do not require clean working dir on release-it.

Release process is failing with:
`WARNING Unable to verify if user botatuphold is a collaborator for @uphold/topper-web-sdk.`

while botatuphold is a collaborator with read/write perms.

