### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,24 +3,26 @@ name: Node CI
 on: [push]
 
 jobs:
-  unit:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [18, 20]
-    name: Node v${{ matrix.node }}
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: ${{ matrix.node }}
+        node-version: 24
+
+    - name: Enable yarn
+      run: corepack enable
 
     - name: Install dependencies
-      run: yarn
+      run: yarn install --frozen-lockfile
 
     - name: Run lint
       run: yarn lint
+
+    - name: Run build
+      run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,23 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    concurrency: 1
+    concurrency:
+      group: release
+      cancel-in-progress: false
     environment: release
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
-        token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+        persist-credentials: false
 
     - name: Setup Node.js version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Enable yarn
       run: corepack enable
@@ -43,6 +47,7 @@ jobs:
       run: |
         git config user.name "Uphold"
         git config user.email "bot@uphold.com"
+        git config --global url.https://${{ secrets.RELEASE_GITHUB_TOKEN }}@github.com/.insteadOf https://github.com/
 
     - name: Generate release
       env:


### PR DESCRIPTION
Update GitHub workflows for Node 24 support, add a build step to CI, and fix the release action's credentials/concurrency setup.